### PR TITLE
Tests were failing because eth_getStorageAt expected 66 size storage slots

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,16 @@ With the ability to control Oracle return values, simulating such scenarios in y
 Oracle manipulation is an additional attack vector. With this method, malicious actors research data sources that various oracle consume as sources of truth. When actors possess the ability to manipulate the underlying data source they trigger downstream effects, manifesting in altered Oracle return values. As a result of manipulated data, actors and contracts can trigger various unwanted behaviours such as modified permissions, transaction execution, emergency pausing / shutdown and more.
 
 With the ability to manipulate Uniswap V3 Oracle return values, simulating such scenarios in your local development environment is possible.
+
+## Development
+
+### Testing
+1. Start a hardhat mainnet fork in a terminal
+```
+npx hardhat node --fork https://mainnet.infura.io/v3/<api-key> --fork-block-number xxxxx
+```
+
+2. Run tests
+```
+npm test
+```

--- a/src/mocker/poolmocker.ts
+++ b/src/mocker/poolmocker.ts
@@ -42,7 +42,8 @@ export class UniSwapPoolMocker {
   }
 
   async OverrideSlot0Tick(n: number): Promise<string> {
-    const st = (await this.provider.send("eth_getStorageAt", [this.poolAddress, "0x0"])) as string;
+    const slot0StorageAddress = `0x${numberToStorage(BigNumber.from(0), 64)}`
+    const st = (await this.provider.send("eth_getStorageAt", [this.poolAddress, slot0StorageAddress])) as string;
     if (n > 16777216 - 1) {
       throw new Error("number to big");
     }
@@ -54,21 +55,23 @@ export class UniSwapPoolMocker {
 
   async OverrideObservationTick(n: BigNumber, index: number): Promise<string> {
     const slot = 8 + index;
-    const add = `0x${slot.toString(16)}`;
-    const st = (await this.provider.send("eth_getStorageAt", [this.poolAddress, add])) as string;
+    const storageAddress = `0x${numberToStorage(BigNumber.from(slot), 64)}`;
+    const hardhatStorageAddress = `0x${slot.toString(16)}`;
+    const st = (await this.provider.send("eth_getStorageAt", [this.poolAddress, storageAddress])) as string;
     const tickHex = numberToStorage(n, 14);
     const newSt = "0x" + st.slice(2, 44) + tickHex + st.slice(-8);
-    await this.provider.send("hardhat_setStorageAt", [this.poolAddress, add, newSt]);
+    await this.provider.send("hardhat_setStorageAt", [this.poolAddress, hardhatStorageAddress, newSt]);
     return newSt;
   }
 
   async OverrideObservationTimestamp(ts: number, index: number): Promise<string> {
     const slot = 8 + index;
-    const add = `0x${slot.toString(16)}`;
-    const st = (await this.provider.send("eth_getStorageAt", [this.poolAddress, add])) as string;
+    const storageAddress = `0x${numberToStorage(BigNumber.from(slot), 64)}`;
+    const hardhatStorageAddress = `0x${slot.toString(16)}`;
+    const st = (await this.provider.send("eth_getStorageAt", [this.poolAddress, storageAddress])) as string;
     const tsHex = numberToStorage(BigNumber.from(ts), 8);
     const newSt = "0x" + st.slice(2, 58) + tsHex;
-    await this.provider.send("hardhat_setStorageAt", [this.poolAddress, add, newSt]);
+    await this.provider.send("hardhat_setStorageAt", [this.poolAddress, hardhatStorageAddress, newSt]);
     return newSt;
   }
 


### PR DESCRIPTION
Was getting the error

```
processing response error (body="{\"jsonrpc\":\"2.0\",\"id\":53,\"error\":{\"code\":-32602,\"message\":\"Errors encountered in param 1: Storage slot argument must have a length of 66 (\\\"0x\\\" + 32 bytes), but '0x8' has a length of 3\",\"data\":{\"message\":\"Errors encountered in param 1: Storage slot argument must have a length of 66 (\\\"0x\\\" + 32 bytes), but '0x8' has a length of 3\"}}}", error={"code":-32602,"data":{"message":"Errors encountered in param 1: Storage slot argument must have a length of 66 (\"0x\" + 32 bytes), but '0x8' has a length of 3"}}, requestBody="{\"method\":\"eth_getStorageAt\",\"params\":[\"0x4e68ccd3e89f51c3074ca5072bbac773960dfa36\",\"0x8\"],\"id\":53,\"jsonrpc\":\"2.0\"}", requestMethod="POST", url="http://localhost:8545", code=SERVER_ERROR, version=web/5.6.0)
```